### PR TITLE
[FEAT] 건너뛰기 로직 리팩토링, UI 개선 (#3)

### DIFF
--- a/VideoPlayApp/View/TableViewCell.swift
+++ b/VideoPlayApp/View/TableViewCell.swift
@@ -6,7 +6,9 @@
 //
 
 import UIKit
+
 import SnapKit
+import Then
 
 class TableViewCell: UITableViewCell {
     
@@ -54,12 +56,15 @@ class TableViewCell: UITableViewCell {
     func setStackView() {
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
-        stackView.spacing = 5
+        stackView.spacing = 10
     }
     
     func setThumbnailImage(_ videoDetails: VideoDetails) {
         let imageURL = videoDetails.thumbnailUrl
-        thumbnailImageView.contentMode = .scaleAspectFill
+        thumbnailImageView.do {
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
+        }
         Task {
             do {
                 let imageData = try await APIManager.shared.fetchUrlData(url: imageURL)

--- a/VideoPlayApp/View/VideoControlView.swift
+++ b/VideoPlayApp/View/VideoControlView.swift
@@ -52,15 +52,13 @@ private extension VideoControlView {
 
     func setLayout() {
         leftView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview()
-            $0.leading.equalToSuperview()
-            $0.width.equalTo(ScreenUtils.width / 2)
+            $0.leading.verticalEdges.equalToSuperview()
+            $0.trailing.equalTo(self.snp.centerX)
         }
 
         rightView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview()
-            $0.trailing.equalToSuperview()
-            $0.width.equalTo(ScreenUtils.width / 2)
+            $0.trailing.verticalEdges.equalToSuperview()
+            $0.leading.equalTo(self.snp.centerX)
         }
 
         leftSkipLabel.snp.makeConstraints {
@@ -72,12 +70,14 @@ private extension VideoControlView {
         }
 
         settingsButton.snp.makeConstraints {
-            $0.trailing.top.equalTo(self.safeAreaLayoutGuide).inset(20)
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.trailing.equalTo(self.safeAreaLayoutGuide).inset(10)
             $0.size.equalTo(60)
         }
 
         xButton.snp.makeConstraints {
-            $0.leading.top.equalTo(self.safeAreaLayoutGuide).inset(20)
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.equalTo(self.safeAreaLayoutGuide).inset(10)
             $0.size.equalTo(60)
         }
 

--- a/VideoPlayApp/View/VideoControlView.swift
+++ b/VideoPlayApp/View/VideoControlView.swift
@@ -21,6 +21,7 @@ class VideoControlView: UIView {
     let settingsButton = UIButton(type: .system)
     let playPauseButton = UIButton(type: .system)
     let loadingIndicator = UIActivityIndicatorView(style: .large)
+    let xButton = UIButton()
 
 
     // MARK: - init
@@ -44,7 +45,7 @@ class VideoControlView: UIView {
 private extension VideoControlView {
     
     func setHierarchy() {
-        [leftView, rightView, settingsButton, playPauseButton, loadingIndicator].forEach { self.addSubview($0) }
+        [leftView, rightView, settingsButton, xButton, playPauseButton, loadingIndicator].forEach { self.addSubview($0) }
         leftView.addSubview(leftSkipLabel)
         rightView.addSubview(rightSkipLabel)
     }
@@ -72,6 +73,11 @@ private extension VideoControlView {
 
         settingsButton.snp.makeConstraints {
             $0.trailing.top.equalTo(self.safeAreaLayoutGuide).inset(20)
+            $0.size.equalTo(60)
+        }
+
+        xButton.snp.makeConstraints {
+            $0.leading.top.equalTo(self.safeAreaLayoutGuide).inset(20)
             $0.size.equalTo(60)
         }
 
@@ -108,6 +114,14 @@ private extension VideoControlView {
             $0.setImage(UIImage(systemName: "gearshape.fill"), for: .normal)
         }
 
+        xButton.do {
+            let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
+            $0.setPreferredSymbolConfiguration(config, forImageIn: .normal)
+            $0.setImage(UIImage(systemName: "xmark"), for: .normal)
+            $0.tintColor = .white
+            
+        }
+
         playPauseButton.do {
             $0.tintColor = .white
             $0.setImage(UIImage(systemName: "pause.fill"), for: .normal)
@@ -121,10 +135,12 @@ private extension VideoControlView {
 extension VideoControlView {
 
     func hideButtons(_ isHidden: Bool) {
-        [settingsButton, playPauseButton].forEach {
-            $0.isHidden = isHidden
+        UIView.animate(withDuration: 0.4) {
+            [self.settingsButton, self.xButton, self.playPauseButton].forEach {
+                $0.layer.opacity = isHidden ? 0.0 : 1.0
+                $0.isHidden = isHidden
+            }
             self.backgroundColor = .black.withAlphaComponent(isHidden ? 0.0 : 0.7)
-
         }
     }
 

--- a/VideoPlayApp/View/VideoControlView.swift
+++ b/VideoPlayApp/View/VideoControlView.swift
@@ -20,6 +20,7 @@ class VideoControlView: UIView {
     let rightSkipLabel = UILabel()
     let settingsButton = UIButton(type: .system)
     let playPauseButton = UIButton(type: .system)
+    let loadingIndicator = UIActivityIndicatorView(style: .large)
 
 
     // MARK: - init
@@ -43,7 +44,7 @@ class VideoControlView: UIView {
 private extension VideoControlView {
     
     func setHierarchy() {
-        [leftView, rightView, settingsButton, playPauseButton].forEach { self.addSubview($0) }
+        [leftView, rightView, settingsButton, playPauseButton, loadingIndicator].forEach { self.addSubview($0) }
         leftView.addSubview(leftSkipLabel)
         rightView.addSubview(rightSkipLabel)
     }
@@ -70,11 +71,16 @@ private extension VideoControlView {
         }
 
         settingsButton.snp.makeConstraints {
-            $0.trailing.top.equalToSuperview().inset(20)
+            $0.trailing.top.equalTo(self.safeAreaLayoutGuide).inset(20)
             $0.size.equalTo(60)
         }
 
         playPauseButton.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(60)
+        }
+
+        loadingIndicator.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.size.equalTo(60)
         }

--- a/VideoPlayApp/View/VideoControlView.swift
+++ b/VideoPlayApp/View/VideoControlView.swift
@@ -16,6 +16,8 @@ class VideoControlView: UIView {
     
     let leftView = UIView()
     let rightView = UIView()
+    let leftSkipLabel = UILabel()
+    let rightSkipLabel = UILabel()
     let settingsButton = UIButton(type: .system)
     let playPauseButton = UIButton(type: .system)
 
@@ -42,6 +44,8 @@ private extension VideoControlView {
     
     func setHierarchy() {
         [leftView, rightView, settingsButton, playPauseButton].forEach { self.addSubview($0) }
+        leftView.addSubview(leftSkipLabel)
+        rightView.addSubview(rightSkipLabel)
     }
 
     func setLayout() {
@@ -55,6 +59,14 @@ private extension VideoControlView {
             $0.verticalEdges.equalToSuperview()
             $0.trailing.equalToSuperview()
             $0.width.equalTo(ScreenUtils.width / 2)
+        }
+
+        leftSkipLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+
+        rightSkipLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
 
         settingsButton.snp.makeConstraints {
@@ -78,6 +90,13 @@ private extension VideoControlView {
             $0.isUserInteractionEnabled = true
             $0.backgroundColor = .clear
         }
+
+        [leftSkipLabel, rightSkipLabel].forEach {
+            $0.textColor = .white
+            $0.font = .systemFont(ofSize: 24, weight: .bold)
+            $0.layer.opacity = 0
+        }
+
         settingsButton.do {
             $0.tintColor = .white
             $0.setImage(UIImage(systemName: "gearshape.fill"), for: .normal)
@@ -103,4 +122,20 @@ extension VideoControlView {
         }
     }
 
+    func setSkipLabel(_ time: Double) {
+        let absTime: Double = abs(time)
+        if time < 0 {
+            leftSkipLabel.text = "- " + String(absTime)
+            leftSkipLabel.layer.opacity = 1
+        } else {
+            rightSkipLabel.text = "+ " + String(absTime)
+            rightSkipLabel.layer.opacity = 1
+        }
+        
+        UIView.animate(withDuration: 1.0) {
+            [self.leftSkipLabel, self.rightSkipLabel].forEach {
+                $0.layer.opacity = 0.0
+            }
+        }
+    }
 }

--- a/VideoPlayApp/View/VideoControlView.swift
+++ b/VideoPlayApp/View/VideoControlView.swift
@@ -144,4 +144,9 @@ extension VideoControlView {
             }
         }
     }
+
+    func setPlayPauseButtonImage(isPlaying: Bool) {
+        let playPauseImg = UIImage(systemName: isPlaying ? "pause.fill" : "play.fill")
+        playPauseButton.setImage(playPauseImg, for: .normal)
+    }
 }

--- a/VideoPlayApp/View/VideoPlayerViewController.swift
+++ b/VideoPlayApp/View/VideoPlayerViewController.swift
@@ -31,7 +31,6 @@ class VideoPlayerViewController: UIViewController {
     private var playerLayer: AVPlayerLayer
     private var playerItem: AVPlayerItem
     private let controlView = VideoControlView()
-    private let xButton = UIButton()
 
 
     // MARK: - init
@@ -86,17 +85,12 @@ private extension VideoPlayerViewController {
 
     func setHierarchy() {
         view.layer.addSublayer(playerLayer)
-        [controlView, xButton].forEach { view.addSubview($0) }
+        view.addSubview(controlView)
     }
 
     func setLayout() {
         controlView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-        }
-
-        xButton.snp.makeConstraints {
-            $0.leading.top.equalTo(view.safeAreaLayoutGuide).inset(20)
-            $0.size.equalTo(60)
         }
     }
 
@@ -105,14 +99,6 @@ private extension VideoPlayerViewController {
         playerLayer.videoGravity = .resizeAspect
 
         controlView.hideButtons(isControlHidden)
-
-        xButton.do {
-            let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
-            $0.setPreferredSymbolConfiguration(config, forImageIn: .normal)
-            $0.setImage(UIImage(systemName: "xmark"), for: .normal)
-            $0.tintColor = .white
-            
-        }
     }
 
     func setGesture() {
@@ -129,7 +115,7 @@ private extension VideoPlayerViewController {
         controlView.playPauseButton.addTarget(self, action: #selector(togglePlayPause), for: .touchUpInside)
 
         // x 버튼
-        xButton.addTarget(self, action: #selector(didTapXButton), for: .touchUpInside)
+        controlView.xButton.addTarget(self, action: #selector(didTapXButton), for: .touchUpInside)
     }
 
 }

--- a/VideoPlayApp/View/VideoPlayerViewController.swift
+++ b/VideoPlayApp/View/VideoPlayerViewController.swift
@@ -12,10 +12,14 @@ class VideoPlayerViewController: UIViewController {
 
     // MARK: - Properties
 
-    private var skipSeconds: Double = 10
-    private var isControlHidden: Bool = false
+    private var skipUnit: Double = 10
+
+    private var skipUITimer: Timer?
     private var tapCount: Int = 0
-    private var tapTimer: Timer?
+    private var accumulatedSkip: Double = 0
+
+    private var isFirstTap = true
+    private var isControlHidden: Bool = false
 
 
     // MARK: - UI Properties
@@ -101,25 +105,11 @@ private extension VideoPlayerViewController {
 private extension VideoPlayerViewController {
 
     @objc func didTapLeft() {
-        tapCount -= 1
-        
-        tapTimer?.invalidate()
-        tapTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
-            guard let self else { return }
-            handleTapCount(tapCount)
-            tapCount = 0
-        }
+        handleTap(isLeft: true)
     }
 
     @objc func didTapRight() {
-        tapCount += 1
-        
-        tapTimer?.invalidate()
-        tapTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
-            guard let self else { return }
-            handleTapCount(tapCount)
-            tapCount = 0
-        }
+        handleTap(isLeft: false)
     }
 
     @objc func openSettings() {
@@ -130,13 +120,13 @@ private extension VideoPlayerViewController {
         alert.addTextField { textField in
             textField.placeholder = "예: 5"
             textField.keyboardType = .numberPad
-            textField.text = "\(Int(self.skipSeconds))"
+            textField.text = "\(Int(self.skipUnit))"
         }
 
         let ok = UIAlertAction(title: "확인", style: .default) { _ in
             if let text = alert.textFields?.first?.text,
                let value = Double(text) {
-                self.skipSeconds = value
+                self.skipUnit = value
             }
         }
 
@@ -184,16 +174,53 @@ private extension VideoPlayerViewController {
         player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
     }
 
-    func handleTapCount(_ count: Int) {
-        print("count: \(count)")
-        if abs(count) == 1 {
-            UIView.animate(withDuration: 0.2) { [weak self] in
-                guard let self else { return }
-                isControlHidden.toggle()
-                controlView.hideButtons(isControlHidden)
-            }
+    func handleTap(isLeft: Bool) {
+        // 즉각적으로 skip UI 업데이트
+        let delta = isLeft ? -skipUnit : +skipUnit
+        tapCount += isLeft ? -1 : +1
+
+        if isFirstTap {
+            // 첫 탭은 싱글 후보 → UI 업데이트 X
+            isFirstTap = false
         } else {
-            seek(by: Double(count - 1) * skipSeconds)
+            // 두 번째 탭부터는 즉각 UI 업데이트
+            accumulatedSkip += delta
+            updateSkipUI(accumulatedSkip)
+        }
+
+        // 타이머 리셋
+        skipUITimer?.invalidate()
+        skipUITimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) { [weak self] _ in
+            self?.processTapResult()
         }
     }
+
+    func processTapResult() {
+        if abs(tapCount) == 1 {
+            toggleControlVisibility()
+        } else {
+            let skipUnits = abs(tapCount) - 1
+            let direction: Double = tapCount > 0 ? 1 : -1
+            let finalSkip = Double(skipUnits) * skipUnit * direction
+
+            seek(by: finalSkip)
+        }
+
+        // Reset
+        tapCount = 0
+        isFirstTap = true
+        accumulatedSkip = 0
+    }
+
+    func updateSkipUI(_ value: Double) {
+        controlView.setSkipLabel(value)
+    }
+
+    func toggleControlVisibility() {
+        isControlHidden.toggle()
+        UIView.animate(withDuration: 0.2) {
+            self.controlView.hideButtons(self.isControlHidden)
+        }
+    }
+
 }

--- a/VideoPlayApp/View/VideoPlayerViewController.swift
+++ b/VideoPlayApp/View/VideoPlayerViewController.swift
@@ -31,6 +31,7 @@ class VideoPlayerViewController: UIViewController {
     private var playerLayer: AVPlayerLayer
     private var playerItem: AVPlayerItem
     private let controlView = VideoControlView()
+    private let xButton = UIButton()
 
 
     // MARK: - init
@@ -85,12 +86,17 @@ private extension VideoPlayerViewController {
 
     func setHierarchy() {
         view.layer.addSublayer(playerLayer)
-        [controlView].forEach { view.addSubview($0) }
+        [controlView, xButton].forEach { view.addSubview($0) }
     }
 
     func setLayout() {
         controlView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+
+        xButton.snp.makeConstraints {
+            $0.leading.top.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.size.equalTo(60)
         }
     }
 
@@ -99,6 +105,14 @@ private extension VideoPlayerViewController {
         playerLayer.videoGravity = .resizeAspect
 
         controlView.hideButtons(isControlHidden)
+
+        xButton.do {
+            let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .semibold)
+            $0.setPreferredSymbolConfiguration(config, forImageIn: .normal)
+            $0.setImage(UIImage(systemName: "xmark"), for: .normal)
+            $0.tintColor = .white
+            
+        }
     }
 
     func setGesture() {
@@ -113,6 +127,9 @@ private extension VideoPlayerViewController {
         
         // 재생/멈춤 버튼
         controlView.playPauseButton.addTarget(self, action: #selector(togglePlayPause), for: .touchUpInside)
+
+        // x 버튼
+        xButton.addTarget(self, action: #selector(didTapXButton), for: .touchUpInside)
     }
 
 }
@@ -167,6 +184,11 @@ private extension VideoPlayerViewController {
 
         animatePlayPauseButton()
     }
+
+    @objc func didTapXButton() {
+        self.dismiss(animated: true)
+    }
+
 }
 
 

--- a/VideoPlayApp/View/ViewController.swift
+++ b/VideoPlayApp/View/ViewController.swift
@@ -76,9 +76,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let videoDetailsArr = self.videoDetailsArr else { return }
         let videoURL = videoDetailsArr[indexPath.row].videoUrl
-        let player = AVPlayer(url: videoURL)
-        let vc = VideoPlayerViewController(player: player)
-        
+        let vc = VideoPlayerViewController(videoURL)
+        vc.modalPresentationStyle = .overFullScreen
         self.present(vc, animated: true)
     }
 }


### PR DESCRIPTION
## 🪵 **작업 브랜치**
- Resolved: #3

## 🥔 **작업 내용**

### 건너뛰기 리팩토링
- 건너뛰기 시 `+ 10.0`, `- 25.0` 등 건너뛴 초를 라벨로 보이게 함
- 더블탭 시, 1회 건너뛰지 않고 2회 건너뛰는 문제 해결

### 기타 개선사항
- 비디오가 로드되는 동안 로딩 인디케이터 추가
- 비디오 로딩 상태 Combine으로 구독하여 UI 업데이트
- 핸드폰 회전 시 레이아웃 업데이트
- x버튼 추가
- TableView Cell Ul 보완

## 📸 스크린샷
|타입 |iPhone 17|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/7009a344-662e-4ec7-bc0b-f314c1b2b1f1" width ="250">|

## 💥 To be sure
- [x] 모든 뷰가 잘 실행되는지 다시 한 번 체크해주세요 !
